### PR TITLE
Fix broken launch parameters

### DIFF
--- a/cfg/valve.rc
+++ b/cfg/valve.rc
@@ -1,9 +1,23 @@
-// Load the base configuration
+// load the base configuration
 //exec default.cfg
+r_decal_cullsize 1
 
-// Run a user script file if present
+// Setup custom controller
+exec joystick.cfg
+
+// run a user script file if present
 exec autoexec.cfg
 
-// Stuff command line statements
+//
+// stuff command line statements
+//
+stuffcmds
+
+// display the startup level
+startupmenu
+
+sv_unlockedchapters 99
+
+// Dyslexic Crosshair setup
 cl_crosshair_file  ""
 cl_crosshair_scale 31.9


### PR DESCRIPTION
Fixes broken launch parameters.

Currently with this mod installed, launch parameters (`-novid`, `-rconpassword`, `+con_var 42`, etc) doesnt work, due to missing `stuffcmds`.

This fixes it and mirrors `valve.rc` from current version of the game (Build `8453904` at the moment of PR).